### PR TITLE
Switch to the package root before running a local lambda function

### DIFF
--- a/lib/RuntimeNode.js
+++ b/lib/RuntimeNode.js
@@ -51,6 +51,12 @@ module.exports = function(S) {
               functionFile    = func.getRootPath(handlerArr[0] + (func.handlerExt || '.js')),
               functionHandler = handlerArr[1];
 
+            // Switch to the root of the lambda package from the handler property
+            const handlerFullPath = func.getRootPath(_.last(func.handler.split('/'))).replace(/\\/g, '/');
+            const packageRoot = handlerFullPath.replace(func.handler, '');
+            const previousDir = process.cwd();
+            process.chdir(packageRoot);
+
             // Load function handler. This has to be done after env vars are set
             // to ensure that they are accessible in the global context.
             const functionCall = require(functionFile)[functionHandler];
@@ -91,6 +97,10 @@ module.exports = function(S) {
               const duration = endTime[0] * 1000 + endTime[1] / 1000000;
               SCli.log("Duration: " + duration.toFixed(2) + " ms");
             })
+            .finally(() => {
+              // Switch back to previous directory
+              process.chdir(previousDir);
+            });
           })
           .catch((err) => {
             SCli.log(`-----------------`);

--- a/lib/RuntimeNode43.js
+++ b/lib/RuntimeNode43.js
@@ -31,6 +31,12 @@ module.exports = function(S) {
               functionFile    = func.getRootPath(handlerArr[0] + (func.handlerExt || '.js')),
               functionHandler = handlerArr[1];
 
+            // Switch to the root of the lambda package from the handler property
+            const handlerFullPath = func.getRootPath(_.last(func.handler.split('/'))).replace(/\\/g, '/');
+            const packageRoot = handlerFullPath.replace(func.handler, '');
+            const previousDir = process.cwd();
+            process.chdir(packageRoot);
+
             // Load function handler. This has to be done after env vars are set
             // to ensure that they are accessible in the global context.
             const functionCall = require(functionFile)[functionHandler];
@@ -73,6 +79,10 @@ module.exports = function(S) {
               const duration = endTime[0] * 1000 + endTime[1] / 1000000;
               SCli.log("Duration: " + duration.toFixed(2) + " ms");
             })
+            .finally(() => {
+              // Switch back to previous directory
+              process.chdir(previousDir);
+            });
           })
           .catch((err) => {
             SCli.log(`-----------------`);


### PR DESCRIPTION
This enables the use of relative paths in your lambda code as if it's running on AWS. Very useful if you're using the `config` NPM for example.
